### PR TITLE
Add benchmark automation

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v4
         with:
           python-version: '3.x'
@@ -20,5 +22,14 @@ jobs:
           pip install -r requirements.txt
       - name: Run tests
         run: PYTHONPATH=. pytest -q
-      - name: Run demo
-        run: python main.py
+      - name: Run benchmark and update README
+        run: python scripts/update_benchmark.py
+      - name: Commit benchmark results
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@users.noreply.github.com"
+          git add README.md
+          git commit -m "Update benchmark results" || echo "No changes"
+          git push
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+integral_tool/__pycache__/
+tests/__pycache__/
+scripts/__pycache__/

--- a/README.md
+++ b/README.md
@@ -13,3 +13,13 @@ python main.py
 
 The script generates random point sources, computes the field on a plane, and
 outputs the amplitude and phase information.
+
+## Benchmark Results
+
+The following table is automatically updated by the GitHub Actions workflow.
+
+<!-- BENCHMARK_START -->
+| Date | Machine | Python | Git | Runtime(s) | Amp shape | Phase shape |
+|------|---------|--------|-----|-----------|-----------|-------------|
+| 2025-06-21T14:03:35.156183Z | Linux-6.12.13-x86_64-with-glibc2.39 | 3.12.10 | 1bb93da | 0.037 | 64x64 | 64x64 |
+<!-- BENCHMARK_END -->

--- a/main.py
+++ b/main.py
@@ -20,6 +20,7 @@ def run_demo():
     A, phi = amplitude_phase(U)
     print(f"Field computed in {duration:.3f} s")
     print(f"Amplitude shape: {A.shape}, phase shape: {phi.shape}")
+    return duration, A.shape, phi.shape
 
 
 if __name__ == "__main__":

--- a/scripts/update_benchmark.py
+++ b/scripts/update_benchmark.py
@@ -1,0 +1,50 @@
+import datetime
+import platform
+import subprocess
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from main import run_demo
+
+START_MARK = "<!-- BENCHMARK_START -->"
+END_MARK = "<!-- BENCHMARK_END -->"
+
+
+def main():
+    duration, amp_shape, phase_shape = run_demo()
+    commit = (
+        subprocess.check_output(["git", "rev-parse", "--short", "HEAD"])\
+        .decode().strip()
+    )
+    machine = platform.platform()
+    pyver = platform.python_version()
+    date = datetime.datetime.utcnow().isoformat() + "Z"
+
+    row = f"| {date} | {machine} | {pyver} | {commit} | {duration:.3f} | {amp_shape[0]}x{amp_shape[1]} | {phase_shape[0]}x{phase_shape[1]} |"
+
+    path = "README.md"
+    text = open(path).read().splitlines()
+    try:
+        start = text.index(START_MARK)
+        end = text.index(END_MARK)
+    except ValueError:
+        raise SystemExit("Benchmark markers not found in README")
+
+    table = text[start + 1:end]
+    if not table or not table[0].startswith("| Date |"):
+        header = [
+            "| Date | Machine | Python | Git | Runtime(s) | Amp shape | Phase shape |",
+            "|------|---------|--------|-----|-----------|-----------|-------------|",
+        ]
+        table = header + [row]
+    else:
+        table.append(row)
+    text[start + 1:end] = table
+    with open(path, "w") as fh:
+        fh.write("\n".join(text) + "\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- make `run_demo` return performance metrics
- add a Python script to update README with benchmark results
- record the benchmark table in README
- create a workflow that runs the benchmark and commits results
- ignore Python caches

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6856bb4107c483239607aa4241fd9f18