### PR TITLE
Fix plot generation in benchmark script

### DIFF
--- a/scripts/update_benchmark.py
+++ b/scripts/update_benchmark.py
@@ -63,7 +63,16 @@ def parse_rows():
                 lines.append(line.strip())
     if not lines:
         return []
-    reader = csv.reader([l.strip("|") for l in lines[1:]])
+    data_lines = []
+    for l in lines[1:]:
+        if not l.strip():
+            continue
+        stripped = l.strip().strip("|")
+        if stripped.startswith("-"):
+            continue
+        data_lines.append(stripped)
+    
+    reader = csv.reader(data_lines, delimiter="|")
     rows = []
     for row in reader:
         if len(row) < 9:


### PR DESCRIPTION
## Summary
- ensure `update_benchmark.py` correctly parses benchmark table rows
- skip header separator lines when building plot data

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d230f6e748323be0a07997a85d8e4